### PR TITLE
Convert int to timedelta into result.elapsed

### DIFF
--- a/testrail/result.py
+++ b/testrail/result.py
@@ -79,6 +79,9 @@ class Result(TestRailBase):
         duration = self._content.get('elapsed')
         if duration is None:
             return None
+        
+        if isinstance(duration, int):
+            return timedelta(seconds=duration)
         return testrail_duration_to_timedelta(duration)
 
     @elapsed.setter


### PR DESCRIPTION
If you set the value of 'elapsed' directly via setter, then call result.elapsed will be error - self._content.get ('elapsed') is not str, but int.